### PR TITLE
OpenOxygenFlowMeter: add warmup and calibration phase

### DIFF
--- a/ARDUINO/OpenOxygenFlowMeter/OpenOxygenFlowMeter.ino
+++ b/ARDUINO/OpenOxygenFlowMeter/OpenOxygenFlowMeter.ino
@@ -15,13 +15,18 @@ int16_t adc0 = -1;
 int16_t mv = 0;
 float oxy_m = 1.92; // needs to be calibrated
 float oxy_b = 0;  // needs to be calibrated (corresponds to the voltage at Oxygen level == 0%)
-float oxygen_level = 0.;
 
+boolean shouldDoWarmupCalibration = true; //change this to false to skip warmup / calibration phase
+unsigned long startTime;
+unsigned static long warmupDelayInMs = 1000 * 60; // 1 minute warmup time before calibrating to 21% oxygen level
 
 // TODO: Need to add a button to start the calibration
 void setup() {
 
   Serial.begin(115200);
+
+  Serial.println("Open Oxygen starting..");
+
   Wire.begin();
 
   // Initialize sensor
@@ -40,25 +45,51 @@ void setup() {
   ads.begin();
   // Setup 3V comparator on channel 0
   ads.startComparator_SingleEnded(0, 1000);
-  
 
-  // Initi display
+
+  // Init display
   lcd.init();
   lcd.clear();
   lcd.backlight();      // Make sure backlight is on
 
   // Print a message on both lines of the LCD.
-  lcd.setCursor(2, 0);  //Set cursor to character 2 on line 0
+  lcd.setCursor(2, 1);  //Set cursor to character 2 on line 1
   lcd.print("     O2       ");
 
-  lcd.setCursor(2, 1);  //Move cursor to character 2 on line 1
+  lcd.setCursor(2, 0);  //Move cursor to character 2 on line 0
   lcd.print("Open Oxygen");
 
-  
+
 }
 
 void loop() {
 
+  boolean warmup = shouldDoWarmupCalibration;
+  boolean doCalibration = false;
+  int remainingWarmupSeconds = 0;
+
+  if(warmup) {
+    long currentTime = millis();
+    warmup = currentTime - startTime < warmupDelayInMs;
+    if(!warmup) {
+      // warmup is over, trigger calibration & skip warmup check in the future
+      shouldDoWarmupCalibration = false;
+      doCalibration = true;
+    } else {
+      remainingWarmupSeconds = int((warmupDelayInMs - currentTime + startTime)/1000)+1;
+    }
+  }
+
+  float flowRate = updateFlowRate();
+  float oxygenLevel = updateOxygenLevel(doCalibration);
+
+  if(warmup) displayWarmup(remainingWarmupSeconds);
+  else displayResults(flowRate, oxygenLevel);
+
+  delay(300);
+}
+
+float updateFlowRate() {
   float diffPressure; // Storage for the differential pressure
   float temperature; // Storage for the temperature
 
@@ -74,32 +105,53 @@ void loop() {
   Serial.print(flowrate);
   Serial.println(F(" (slm)"));
 
-  String out_flow;
-  out_flow += F("Flow: ");
-  out_flow += String(flowrate, 5);
+  return flowrate;
+}
 
+float updateOxygenLevel(boolean doCalibration) {
   // Read the ADC value from the bus:
-  adc0 = ads.getLastConversionResults();
+   adc0 = ads.getLastConversionResults();
+  if(doCalibration) {
+    String msg = "Calibrating oxy_m to ";
+    msg += String(adc0) + "..";
+    Serial.print(msg);
+    oxy_m = adc0;
+  }
   //Serial.print("AIN0: "); Serial.println(adc0);
   // http://cool-web.de/esp8266-esp32/ads1115-16bit-adc-am-esp32-voltmeter.htm
-  oxygen_level = adc0 * 0.1875 * oxy_m + oxy_b;
+  float oxygenLevel = adc0 * 0.1875 * oxy_m + oxy_b;
 
-  Serial.print("Oxygenlevel: "); Serial.print(oxygen_level); Serial.println(" %");
+  Serial.print("Oxygenlevel: "); Serial.print(oxygenLevel); Serial.println(" %");
   Serial.print("ADC: "); Serial.println(adc0);
+  return oxygenLevel;
+
+}
+
+void displayWarmup(int remainingSeconds) {
+  String msg = "Warmup.. (";
+  msg = msg + remainingSeconds + ")    ";
+  msg = msg.substring(0, 16);
+  Serial.println(msg);
+  lcd.setCursor(0, 1);
+  lcd.print(msg);
+}
+
+void displayResults(float flowRate, float oxygenLevel) {
+  String out_flow;
+  out_flow += F("Flow: ");
+  out_flow += String(flowRate, 5);
+
   String out_oxy;
   out_oxy += F("Oxygen: ");
-  out_oxy += String(oxygen_level, 4);
+  out_oxy += String(oxygenLevel, 4);
 
   // TODO: NEED TO combine the two strings properly!
-  lcd.setCursor(0, 0);  //Set cursor to character 2 on line 0
+  lcd.setCursor(0, 0);
   lcd.print(out_flow);
 
   lcd.setCursor(0, 1);
   lcd.print(out_oxy);
-
-delay(2);
 }
-
 
 float convert2slm(float dp) {
   // convert the differential presure dp into the standard liter per minute


### PR DESCRIPTION
This change adds a warmup and calibration phase to the flow meter:
- in the warmup phase (one minute) it's not displaying measurements on the display
- afterwards, it sets `oxy_m` to the current value of the `ads` - we should probably do a sanity check here and define boundaries

This code is tested without sensors - only with the controller + display. Grateful for feedback!